### PR TITLE
Rehome chat console under Devagent namespace

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,9 @@ PATH
   specs:
     devagent (0.1.0)
       diffy (~> 3.4)
+      faraday (~> 2.9)
       json-schema (~> 4.3)
+      paint (~> 2.2)
       parallel (~> 1.24)
       thor (~> 1.3)
       tty-reader (~> 0.9)
@@ -21,6 +23,12 @@ GEM
     diff-lcs (1.6.2)
     diffy (3.4.4)
     erb (5.0.2)
+    faraday (2.13.4)
+      faraday-net_http (>= 2.0, < 3.5)
+      json
+      logger
+    faraday-net_http (3.4.1)
+      net-http (>= 0.5.0)
     io-console (0.8.1)
     irb (1.15.2)
       pp (>= 0.6.0)
@@ -31,6 +39,10 @@ GEM
       addressable (>= 2.8)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
+    logger (1.7.0)
+    net-http (0.6.0)
+      uri
+    paint (2.3.0)
     parallel (1.27.0)
     parser (3.3.9.0)
       ast (~> 2.4.1)
@@ -103,6 +115,7 @@ GEM
     unicode-display_width (3.2.0)
       unicode-emoji (~> 4.1)
     unicode-emoji (4.1.0)
+    uri (1.0.3)
     wisper (2.0.1)
     zeitwerk (2.7.3)
 

--- a/devagent.gemspec
+++ b/devagent.gemspec
@@ -41,7 +41,9 @@ Gem::Specification.new do |spec|
 
   # === Runtime dependencies (keep light) ===
   spec.add_dependency "diffy", "~> 3.4"
+  spec.add_dependency "faraday", "~> 2.9"
   spec.add_dependency "json-schema", "~> 4.3"
+  spec.add_dependency "paint", "~> 2.2"
   spec.add_dependency "parallel", "~> 1.24"
   spec.add_dependency "thor", "~> 1.3"
   spec.add_dependency "tty-reader", "~> 0.9"

--- a/lib/devagent/chat/client.rb
+++ b/lib/devagent/chat/client.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "json"
+require "faraday"
+require "paint"
+
+module Devagent
+  module Chat
+    # Client encapsulates streaming chat interactions with the local Ollama server.
+    class Client
+      DEFAULT_URL = "http://localhost:11434"
+      DEFAULT_SYSTEM_PROMPT = "You are a concise, helpful assistant designed for a terminal environment."
+
+      attr_reader :model, :history, :system_prompt
+
+      def initialize(model:, system_prompt: ENV.fetch("DEVAGENT_CHAT_SYSTEM_PROMPT", DEFAULT_SYSTEM_PROMPT), base_url: DEFAULT_URL)
+        @model = model
+        @system_prompt = system_prompt
+        @base_url = base_url
+        @history = []
+        @json_buffer = ""
+        @assistant_response_content = ""
+        @conn = build_connection
+        seed_system_prompt
+      end
+
+      def server_available?
+        @conn.get("/api/version")
+        true
+      rescue Faraday::ConnectionFailed, Faraday::TimeoutError
+        false
+      end
+
+      def ensure_server_available!
+        return if server_available?
+
+        raise Faraday::ConnectionFailed, "Unable to connect to Ollama server at #{@base_url}"
+      end
+
+      def chat_stream(prompt, output: $stdout, color: :cyan)
+        append_user_message(prompt)
+        reset_stream_state
+
+        @conn.post("/api/chat") do |req|
+          req.headers["Content-Type"] = "application/json"
+          req.body = JSON.generate(
+            model: @model,
+            messages: build_messages,
+            stream: true
+          )
+          req.options.on_data = proc do |chunk, _size|
+            process_chunk(chunk, output, color)
+          end
+        end
+
+        append_assistant_message
+        output.puts
+      rescue Faraday::Error => e
+        output.puts Paint["Error communicating with Ollama: #{e.message}", :red]
+      end
+
+      def switch_model!(new_model)
+        return if new_model.nil? || new_model.strip.empty?
+
+        @model = new_model
+      end
+
+      private
+
+      def build_connection
+        Faraday.new(url: @base_url, request: { open_timeout: 5, timeout: 30 }) do |faraday|
+          faraday.response :raise_error
+          faraday.adapter Faraday.default_adapter
+        end
+      end
+
+      def seed_system_prompt
+        return if @system_prompt.nil? || @system_prompt.strip.empty?
+
+        @history << { role: "system", content: @system_prompt }
+      end
+
+      def append_user_message(prompt)
+        @history << { role: "user", content: prompt }
+      end
+
+      def append_assistant_message
+        @history << { role: "assistant", content: @assistant_response_content.dup }
+      end
+
+      def build_messages
+        @history
+      end
+
+      def reset_stream_state
+        @json_buffer = ""
+        @assistant_response_content = ""
+      end
+
+      def process_chunk(chunk, output, color)
+        @json_buffer << chunk
+        lines = @json_buffer.split("\n")
+        @json_buffer = lines.pop || ""
+
+        lines.each do |line|
+          next if line.strip.empty?
+
+          begin
+            data = JSON.parse(line)
+          rescue JSON::ParserError
+            @json_buffer.prepend(line)
+            next
+          end
+
+          if data["error"]
+            output.print(Paint["\nError: #{data["error"]}\n", :red])
+            output.flush if output.respond_to?(:flush)
+            next
+          end
+
+          if data["message"] && data["message"]["content"]
+            content = data["message"]["content"]
+            @assistant_response_content << content
+            output.print(Paint[content, color])
+            output.flush if output.respond_to?(:flush)
+          end
+
+          next unless data["done"]
+
+          if data["done_reason"] == "stop"
+            # normal completion
+          elsif data["done_reason"]
+            output.print(Paint["\n(#{data["done_reason"]})", :yellow])
+            output.flush if output.respond_to?(:flush)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/devagent/chat/session.rb
+++ b/lib/devagent/chat/session.rb
@@ -1,0 +1,97 @@
+# frozen_string_literal: true
+
+require "paint"
+require "faraday"
+
+module Devagent
+  module Chat
+    # Session implements the interactive console loop for chatting with Ollama.
+    class Session
+      def initialize(model:, input: $stdin, output: $stdout)
+        @input = input
+        @output = output
+        @client = Client.new(model: model)
+      end
+
+      def start
+        unless @client.server_available?
+          @output.puts Paint["Unable to connect to Ollama server at #{Client::DEFAULT_URL}.", :red]
+          @output.puts Paint["Please ensure the Ollama daemon is running (ollama serve).", :red]
+          return false
+        end
+
+        @output.puts Paint["Connected. Type /exit or /quit to leave the console.", :green]
+        repl_loop
+        true
+      rescue Faraday::Error => e
+        @output.puts Paint["Connection error: #{e.message}", :red]
+        false
+      end
+
+      private
+
+      def repl_loop
+        loop do
+          prompt
+          input = @input.gets
+          break if input.nil?
+
+          input = input.chomp
+          next if input.strip.empty?
+
+          break if %w[exit quit].include?(input.strip.downcase)
+
+          if input.start_with?("/")
+            handle_meta_command(input)
+            next
+          end
+
+          @client.chat_stream(input, output: @output)
+        end
+
+        @output.puts Paint["Goodbye!", :yellow]
+      end
+
+      def prompt
+        @output.print(Paint[" > ", :green])
+        @output.flush if @output.respond_to?(:flush)
+      end
+
+      def handle_meta_command(input)
+        command, *args = input.strip.split
+
+        case command
+        when "/history"
+          display_history
+        when "/model"
+          switch_model(args.first)
+        else
+          @output.puts Paint["Unknown command: #{command}", :red]
+        end
+      end
+
+      def display_history
+        @output.puts Paint["Conversation history:", :yellow]
+        @client.history.each do |message|
+          label = message[:role].capitalize.ljust(9)
+          color = case message[:role]
+                  when "user" then :green
+                  when "assistant" then :cyan
+                  else :yellow
+                  end
+          @output.puts Paint["#{label}: #{message[:content]}", color]
+        end
+      end
+
+      def switch_model(new_model)
+        if new_model.nil?
+          @output.puts Paint["Usage: /model <model_name>", :yellow]
+          return
+        end
+
+        @client.switch_model!(new_model)
+        @output.puts Paint["Switched to model #{new_model}. Note: existing conversation history will still be sent to the new model.", :yellow]
+      end
+    end
+  end
+end

--- a/lib/devagent/cli.rb
+++ b/lib/devagent/cli.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "thor"
+require "paint"
 require_relative "context"
 require_relative "auto"
 require_relative "diagnostics"
@@ -16,6 +17,17 @@ module Devagent
     def start
       ctx = Context.build(Dir.pwd)
       Auto.new(ctx, input: $stdin, output: $stdout).repl
+    end
+
+    desc "console", "Start an interactive chat console session with Ollama"
+    method_option :model,
+                  aliases: "-m",
+                  default: "llama2",
+                  desc: "The model to use (must be available in Ollama)"
+    def console
+      say Paint["Starting interactive session with Ollama (model: #{options[:model]})", :yellow]
+      session = Chat::Session.new(model: options[:model], input: $stdin, output: $stdout)
+      session.start
     end
 
     desc "test", "Run diagnostics to verify configuration and Ollama connectivity"


### PR DESCRIPTION
## Summary
- move the streaming chat client into the Devagent::Chat namespace and drop the previous OllamaCLI files
- expose the interactive console from the existing Devagent Thor CLI with a configurable model option
- remove the extra executable so the gem continues to run everything through `devagent`

## Testing
- bundle exec exe/devagent help *(fails: missing locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_68d752ba7540832a80d746eb41884a98